### PR TITLE
Add PlayerMixin to use advancements and rotation to detect player motility

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright © 2022–2023 Bytzo
+Copyright © 2022–2023 Bytzo and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/net/bytzo/sessility/SessilityProperties.java
+++ b/src/main/java/net/bytzo/sessility/SessilityProperties.java
@@ -14,10 +14,8 @@ public class SessilityProperties extends Settings<SessilityProperties> {
 	public final boolean skipSessileInPlayerCount = this.get("skip-sessile-in-player-count", false);
 	public final boolean hideSessileInTabList = this.get("hide-sessile-in-tab-list", false);
 	public final boolean hideSessileInServerList = this.get("hide-sessile-in-server-list", false);
-	public final boolean advancementActionDetection = this.get("advancement-action-detection", true);
-	public final boolean advancementInteractDetection = this.get("advancement-interact-detection", true);
-	public final boolean advancementDebugMessages = this.get("advancement-debug-messages", false);
-	public final boolean rotationTriggersMotility = this.get("rotation-triggers-motility", true);
+	public final boolean detectAdvancementAction = this.get("detect-advancement-action", true);
+	public final boolean detectRotation = this.get("detect-rotation", true);
 
 	public SessilityProperties(Properties properties) {
 		super(properties);

--- a/src/main/java/net/bytzo/sessility/SessilityProperties.java
+++ b/src/main/java/net/bytzo/sessility/SessilityProperties.java
@@ -17,6 +17,7 @@ public class SessilityProperties extends Settings<SessilityProperties> {
 	public final boolean advancementActionDetection = this.get("advancement-action-detection", true);
 	public final boolean advancementInteractDetection = this.get("advancement-interact-detection", true);
 	public final boolean advancementDebugMessages = this.get("advancement-debug-messages", false);
+	public final boolean rotationTriggersMotility = this.get("rotation-triggers-motility", true);
 
 	public SessilityProperties(Properties properties) {
 		super(properties);

--- a/src/main/java/net/bytzo/sessility/SessilityProperties.java
+++ b/src/main/java/net/bytzo/sessility/SessilityProperties.java
@@ -14,6 +14,9 @@ public class SessilityProperties extends Settings<SessilityProperties> {
 	public final boolean skipSessileInPlayerCount = this.get("skip-sessile-in-player-count", false);
 	public final boolean hideSessileInTabList = this.get("hide-sessile-in-tab-list", false);
 	public final boolean hideSessileInServerList = this.get("hide-sessile-in-server-list", false);
+	public final boolean advancementActionDetection = this.get("advancement-action-detection", true);
+	public final boolean advancementInteractDetection = this.get("advancement-interact-detection", true);
+	public final boolean advancementDebugMessages = this.get("advancement-debug-messages", false);
 
 	public SessilityProperties(Properties properties) {
 		super(properties);

--- a/src/main/java/net/bytzo/sessility/mixins/PlayerMixin.java
+++ b/src/main/java/net/bytzo/sessility/mixins/PlayerMixin.java
@@ -1,0 +1,106 @@
+package net.bytzo.sessility.mixins;
+
+import java.util.Collections;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.Set;
+import java.util.HashSet;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.bytzo.sessility.Sessility;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
+
+import org.apache.logging.log4j.LogManager;
+
+
+@Mixin(Player.class)
+public abstract class PlayerMixin {
+
+	/* begin advancement code
+	 *
+	 * The following advancements are unused for triggering motility:
+	 *	 damage_dealt_absorbed, damage_dealt_resisted, damage_taken, damage_absorbed, damage_resisted,
+	 *	 deaths, picked_up, killed_by, leave_game, play_time, total_world_time, time_since_death,
+	 *	 time_since_rest, raid_trigger, raid_win
+	 *
+	 * The Following advancements are probably not useful, or are already covered by other cases:
+	 *	 broken, picked_up, dropped, killed, damage_dealt, mob_kills, player_kills, sneak_time, target_hit
+	 *
+	 * Any of the advancements named ???_one_cm (walk_one_cm, fly_one_cm, etc) *could* be used to track when a player moves,
+	 * except that the events are fired when the player is pushed by the environment making determining actual input difficult.
+	 *
+	 * Final note, surprisingly, damage_dealt is not triggered by the thorns enchantment.
+ */
+
+	/* Advancement action list.  Actions taken within the world that are deliberate and visible. */
+	private static Set<String> advancementActionList =
+		Stream.of("mined", "used", "jump", "drop", "damage_blocked_by_shield", "fish_caught", "sleep_in_bed")
+		.collect(Collectors.collectingAndThen(Collectors.toCollection(HashSet::new),Collections::unmodifiableSet));
+
+	/* Advancement interaction list.	Actions relating to interacting with the environment.
+	 * Wildcard rules apply to advancements starting with "interact_with_", "inspect_", "and open_",
+	 * so they are unlisted here. */
+	private static Set<String> advancementInteractList =
+		Stream.of("crafted", "talked_to_villager", "traded_with_villager", "eat_cake_slice", "fill_cauldron", "use_cauldron",
+							"play_noteblock", "tune_noteblock", "pot_flower", "trigger_trapped_chest", "enchant_item",
+							"play_record", "bell_ring")
+		.collect(Collectors.collectingAndThen(Collectors.toCollection(HashSet::new),Collections::unmodifiableSet));
+
+	/* optionally prints advancement debugging information */
+	private void advancement_debug(String state, String playername, String advancement) {
+		if (!Sessility.settings().properties().advancementDebugMessages) return;
+		LogManager.getLogger().info("{}: {} {}", playername, state, advancement);
+	}
+
+	/* use advancements as potential motility detectors */
+	private void processAdvancement(ServerPlayer player, String advancement, int count) {
+
+		// process advancement action list
+		if (Sessility.settings().properties().advancementActionDetection && advancementActionList.contains(advancement)) {
+			advancement_debug("[action]", player.getName().getString(), advancement);
+			player.resetLastActionTime();
+			return;
+		}
+
+		// process advancement interact list and wildcard filters
+		if (Sessility.settings().properties().advancementInteractDetection &&
+				 (advancementInteractList.contains(advancement) ||
+					advancement.startsWith("interact_with_") ||
+					advancement.startsWith("inspect_") ||
+					advancement.startsWith("open_")
+				 )
+			 ) {
+			advancement_debug("[interact]", player.getName().getString(), advancement);
+			player.resetLastActionTime();
+			return;
+		}
+
+		/* Unfortunately, advancements regarding movement are affected by non-player related actions.
+		 * If a reliable way to detect this is found, advancement.endsWith("_one_cm") might be usable. */
+	}
+
+	/* advancement hook for awardStat(ResourceLocation) */
+	@Inject(method = "awardStat(Lnet/minecraft/resources/ResourceLocation;)V", at = @At("HEAD"))
+	private void preAwardStat(ResourceLocation res, CallbackInfo callbackInfo) {
+		processAdvancement(((ServerPlayer)(Object)this), res.getPath(), 1);
+	}
+
+	/* advancement hook for awardStat(ResourceLocation, int) */
+	@Inject(method = "awardStat(Lnet/minecraft/resources/ResourceLocation;I)V", at = @At("HEAD"))
+	private void preAwardStat(ResourceLocation res, int value, CallbackInfo callbackInfo) {
+		processAdvancement(((ServerPlayer)(Object)this), res.getPath(), value);
+	}
+
+	/* end of advancement code */
+}

--- a/src/main/java/net/bytzo/sessility/mixins/PlayerMixin.java
+++ b/src/main/java/net/bytzo/sessility/mixins/PlayerMixin.java
@@ -103,4 +103,30 @@ public abstract class PlayerMixin {
 	}
 
 	/* end of advancement code */
+
+
+	@Unique
+	double last_xRot, last_yRot;
+
+	/* detect when a player rotates */
+	@Inject(method = "travel(Lnet/minecraft/world/phys/Vec3;)V", at = @At("HEAD"))
+	private void preTravel(Vec3 vec3, CallbackInfo callbackInfo) {
+		if (!Sessility.settings().properties().rotationTriggersMotility) return;
+
+		ServerPlayer player = (ServerPlayer)(Object)this;
+		if (player.getVehicle() != null || player.isPassenger()) return;	// doesn't work right with vehicles currently
+
+		double xRot = player.getXRot();
+		double yRot = player.getYRot();
+
+		// detect player rotation
+		if (last_xRot != xRot || last_yRot != yRot)
+			player.resetLastActionTime();
+
+		// This would be a good place to detect movement, but as above non-player actions are hard to discern.
+
+		// update trackers
+		last_xRot = xRot;
+		last_yRot = yRot;
+	}
 }

--- a/src/main/java/net/bytzo/sessility/mixins/PlayerMixin.java
+++ b/src/main/java/net/bytzo/sessility/mixins/PlayerMixin.java
@@ -15,43 +15,41 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import net.bytzo.sessility.Sessility;
 import net.bytzo.sessility.SessilePlayer;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.phys.Vec3;
 
 
 @Mixin(Player.class)
 public abstract class PlayerMixin {
-
 	/* begin advancement code
 	 *
 	 * The following advancements are unused for triggering motility:
-	 * 	- damage_dealt_absorbed, damage_dealt_resisted, damage_taken, damage_absorbed, damage_resisted,
-	 *        deaths, picked_up, killed_by, leave_game, play_time, total_world_time, time_since_death,
-	 *        time_since_rest, raid_trigger, raid_win
+	 * - damage_dealt_absorbed, damage_dealt_resisted, damage_taken, damage_absorbed, damage_resisted,
+	 *   deaths, picked_up, killed_by, leave_game, play_time, total_world_time, time_since_death,
+	 *   time_since_rest, raid_trigger, raid_win
 	 *
 	 * Bytzo has stated Sessility already marks players as motile when they:
-	 *	- Start/Abort/Finish breaking a block
-	 *	- Place a block
-	 *	- Use item(s)
-	 *	- Carry item(s) within an inventory
-	 *	- Send a chat message
-	 *	- Swing their arm (punching)
-	 *	- Sneak/Leave a bed/Sprint/Jump a vehicle/Opens a vehicle inventory/Activate their elytra
-	 *	- Punch an entity
-	 *	- Send a command
-	 *	- Set item(s) in a container
-	 *	- Select a crafting recipe
-	 *	- Click a menu button (enchanting table, loom, etc.)
+	 * - Start/Abort/Finish breaking a block
+	 * - Place a block
+	 * - Use item(s)
+	 * - Carry item(s) within an inventory
+	 * - Send a chat message
+	 * - Swing their arm (punching)
+	 * - Sneak/Leave a bed/Sprint/Jump a vehicle/Opens a vehicle inventory/Activate their elytra
+	 * - Punch an entity
+	 * - Send a command
+	 * - Set item(s) in a container
+	 * - Select a crafting recipe
+	 * - Click a menu button (enchanting table, loom, etc.)
 	 *
 	 * The following advancements are presumably redundant in that statement:
-	 *	- mined, used, drop, damage_blocked_by_shield, fish_caught, sleep_in_bed,
-	 *	  crafted, talked_to_villager, traded_with_villager, eat_cake_slice, fill_cauldron, use_cauldron,
-	 *	  play_noteblock, tune_noteblock, pot_flower, trigger_trapped_chest, enchant_item, play_record, bell_ring
-	 *	- any advancements starting with interact_with, inspect_, open_
+	 * - mined, used, drop, damage_blocked_by_shield, fish_caught, sleep_in_bed,
+	 *   crafted, talked_to_villager, traded_with_villager, eat_cake_slice, fill_cauldron, use_cauldron,
+	 *   play_noteblock, tune_noteblock, pot_flower, trigger_trapped_chest, enchant_item, play_record, bell_ring
+	 * - any advancements starting with interact_with, inspect_, open_
 	 *
 	 * The following advancements are probably not useful, or are already covered by other cases:
-	 *	- broken, picked_up, dropped, killed, damage_dealt, mob_kills, player_kills, sneak_time, target_hit
+	 * - broken, picked_up, dropped, killed, damage_dealt, mob_kills, player_kills, sneak_time, target_hit
 	 *
 	 * Any of the advancements named ???_one_cm (walk_one_cm, fly_one_cm, etc) *could* be used to track when a player moves,
 	 * except that the events are fired when the player is pushed by the environment making determining actual input difficult.
@@ -61,32 +59,31 @@ public abstract class PlayerMixin {
 	 * Final note, surprisingly, damage_dealt is not triggered by the thorns enchantment.
 	 */
 
-	/* Advancement action list.  Actions taken within the world that are deliberate and visible. */
+	/* Advancement action list. Actions taken within the world that are deliberate and visible. */
+	@Unique
 	private static Set<String> advancementActionList =
-		Stream.of("jump")  // only leaving this as a set for possible future additions
-		.collect(Collectors.collectingAndThen(Collectors.toCollection(HashSet::new),Collections::unmodifiableSet));
+			Stream.of("jump")  // only leaving this as a set for possible future additions
+			.collect(Collectors.collectingAndThen(Collectors.toCollection(HashSet::new), Collections::unmodifiableSet));
 
 	@Unique
 	/* use advancements as potential motility detectors */
-	private void processAdvancement(ServerPlayer player, String advancement, int count) {
-
+	private void processAdvancement(String advancement) {
 		// process advancement action list
 		if (Sessility.settings().properties().detectAdvancementAction && advancementActionList.contains(advancement)) {
-			((SessilePlayer)(Object)player).setSessile(false);
-			return;
+			((SessilePlayer) this).setSessile(false);
 		}
 	}
 
 	/* advancement hook for awardStat(ResourceLocation) */
 	@Inject(method = "awardStat(Lnet/minecraft/resources/ResourceLocation;)V", at = @At("HEAD"))
 	private void preAwardStat(ResourceLocation res, CallbackInfo callbackInfo) {
-		processAdvancement(((ServerPlayer)(Object)this), res.getPath(), 1);
+		this.processAdvancement(res.getPath());
 	}
 
 	/* advancement hook for awardStat(ResourceLocation, int) */
 	@Inject(method = "awardStat(Lnet/minecraft/resources/ResourceLocation;I)V", at = @At("HEAD"))
 	private void preAwardStat(ResourceLocation res, int value, CallbackInfo callbackInfo) {
-		processAdvancement(((ServerPlayer)(Object)this), res.getPath(), value);
+		this.processAdvancement(res.getPath());
 	}
 
 	/* end of advancement code */
@@ -98,24 +95,29 @@ public abstract class PlayerMixin {
 	/* detect when a player rotates */
 	@Inject(method = "travel(Lnet/minecraft/world/phys/Vec3;)V", at = @At("HEAD"))
 	private void preTravel(Vec3 vec3, CallbackInfo callbackInfo) {
-		if (!Sessility.settings().properties().detectRotation) return;
+		if (!Sessility.settings().properties().detectRotation) {
+			return;
+		}
 
-		ServerPlayer player = (ServerPlayer)(Object)this;
+		var player = (Player) (Object) this;
 
 		// doesn't work right with vehicles currently
-		if (player.getVehicle() != null || player.isPassenger()) return;
+		if (player.getVehicle() != null || player.isPassenger()) {
+			return;
+		}
 
 		double xRot = player.getXRot();
 		double yRot = player.getYRot();
 
 		// detect player rotation
-		if (last_xRot != xRot || last_yRot != yRot)
-			((SessilePlayer)(Object)player).setSessile(false);
+		if (this.last_xRot != xRot || this.last_yRot != yRot) {
+			((SessilePlayer) player).setSessile(false);
+		}
 
 		// This would be a good place to detect movement, but as above non-player actions are hard to discern.
 
 		// update trackers
-		last_xRot = xRot;
-		last_yRot = yRot;
+		this.last_xRot = xRot;
+		this.last_yRot = yRot;
 	}
 }

--- a/src/main/java/net/bytzo/sessility/mixins/ServerPlayerMixin.java
+++ b/src/main/java/net/bytzo/sessility/mixins/ServerPlayerMixin.java
@@ -34,15 +34,13 @@ public abstract class ServerPlayerMixin extends Player implements SessilePlayer 
 
 	@Unique
 	private boolean sessile = false;
+
 	@Unique
 	private long lastMotileTime = Util.getMillis();
 
 	public ServerPlayerMixin(Level level, BlockPos spawnPos, float spawnAngle, GameProfile gameProfile) {
 		super(level, spawnPos, spawnAngle, gameProfile);
 	}
-
-	@Shadow
-	public abstract long getLastActionTime();
 
 	@Inject(method = "tick()V", at = @At(value = "RETURN"))
 	private void postTick(CallbackInfo callbackInfo) {
@@ -52,7 +50,7 @@ public abstract class ServerPlayerMixin extends Player implements SessilePlayer 
 			return;
 		}
 
-		var idleTime = Util.getMillis() - lastMotileTime;
+		var idleTime = Util.getMillis() - this.lastMotileTime;
 		var timeout = Sessility.settings().properties().sessileTimeout * 1000;
 
 		// If idle longer than the timeout, make the player sessile.
@@ -84,8 +82,9 @@ public abstract class ServerPlayerMixin extends Player implements SessilePlayer 
 	@Unique
 	public void setSessile(boolean sessile) {
 		// Update lastMotileTime if sessile is being set to false
-		if (sessile == false)
-			lastMotileTime = Util.getMillis();
+		if (sessile == false) {
+			this.lastMotileTime = Util.getMillis();
+		}
 
 		// Only update the player's sessility if it has changed. This prevents
 		// unnecessarily broadcasting the player's display name to all players.

--- a/src/main/java/net/bytzo/sessility/mixins/ServerPlayerMixin.java
+++ b/src/main/java/net/bytzo/sessility/mixins/ServerPlayerMixin.java
@@ -34,10 +34,8 @@ public abstract class ServerPlayerMixin extends Player implements SessilePlayer 
 
 	@Unique
 	private boolean sessile = false;
-  @Unique
-  private long lastMotileTime = Util.getMillis();
-  @Unique
-  private long actionTimeTracker = getLastActionTime();
+	@Unique
+	private long lastMotileTime = Util.getMillis();
 
 	public ServerPlayerMixin(Level level, BlockPos spawnPos, float spawnAngle, GameProfile gameProfile) {
 		super(level, spawnPos, spawnAngle, gameProfile);
@@ -53,13 +51,6 @@ public abstract class ServerPlayerMixin extends Player implements SessilePlayer 
 		if (Sessility.settings().properties().sessileTimeout <= 0 || this.sessile) {
 			return;
 		}
-
-    // update lastMotileTime if it is older than a stale lastActionTime
-    var lastActionTime = this.getLastActionTime();
-    if (lastActionTime < actionTimeTracker) {
-      lastMotileTime = actionTimeTracker;
-      actionTimeTracker = lastActionTime;
-    }
 
 		var idleTime = Util.getMillis() - lastMotileTime;
 		var timeout = Sessility.settings().properties().sessileTimeout * 1000;
@@ -92,9 +83,9 @@ public abstract class ServerPlayerMixin extends Player implements SessilePlayer 
 	@Override
 	@Unique
 	public void setSessile(boolean sessile) {
-    // Update lastMotileTime if sessile is being set to false
-    if (sessile == false)
-      lastMotileTime = Util.getMillis();
+		// Update lastMotileTime if sessile is being set to false
+		if (sessile == false)
+			lastMotileTime = Util.getMillis();
 
 		// Only update the player's sessility if it has changed. This prevents
 		// unnecessarily broadcasting the player's display name to all players.

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -30,6 +30,14 @@
 			}
 		}
 	],
+	"contributors": [
+		{
+			"name": "donington",
+			"contact": {
+				"homepage": "https://github.com/donington"
+			}
+		}
+	],
 	"contact": {
 		"issues": "https://github.com/bytzo/sessility/issues",
 		"sources": "https://github.com/bytzo/sessility"

--- a/src/main/resources/sessility.mixins.json
+++ b/src/main/resources/sessility.mixins.json
@@ -6,6 +6,7 @@
 	"server": [
 		"ClientboundPlayerInfoUpdatePacketEntryMixin",
 		"MinecraftServerMixin",
+		"PlayerMixin",
 		"ServerPlayerMixin",
 		"SettingsMixin",
 		"SleepStatusMixin"


### PR DESCRIPTION
Using advancements to detect various player actions and interactions with the world around them to trigger motile.

Also added basic rotation detection as a starting point, but it is specifically disabled in vehicles since they cause the player to rotate triggering false positives.

Options to disable these features have been added as well.