### PR TITLE
Add option to disable action detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ detect-advancement-action=true
 # Default: true
 detect-rotation=true
 
+# Whether or not to detect player action (hitting, breaking blocks or moving) as motility.
+# Default: true
+detect-action=true
+
 # Whether or not to hide sessile players in the player tab list.
 # Default: false
 hide-sessile-in-tab-list=false

--- a/src/main/java/net/bytzo/sessility/SessilityProperties.java
+++ b/src/main/java/net/bytzo/sessility/SessilityProperties.java
@@ -16,6 +16,7 @@ public class SessilityProperties extends Settings<SessilityProperties> {
 	public final boolean hideSessileInServerList = this.get("hide-sessile-in-server-list", false);
 	public final boolean detectAdvancementAction = this.get("detect-advancement-action", true);
 	public final boolean detectRotation = this.get("detect-rotation", true);
+	public final boolean detectAction = this.get("detect-action", true);
 
 	public SessilityProperties(Properties properties) {
 		super(properties);

--- a/src/main/java/net/bytzo/sessility/mixins/ServerPlayerMixin.java
+++ b/src/main/java/net/bytzo/sessility/mixins/ServerPlayerMixin.java
@@ -61,8 +61,10 @@ public abstract class ServerPlayerMixin extends Player implements SessilePlayer 
 
 	@Inject(method = "resetLastActionTime()V", at = @At("HEAD"))
 	private void preResetLastActionTime(CallbackInfo callbackInfo) {
-		// If action is taken, make the player not sessile.
-		this.setSessile(false);
+		if (Sessility.settings().properties().detectAction) {
+			// If action is taken, make the player not sessile.
+			this.setSessile(false);
+		}
 	}
 
 	@Inject(method = "getTabListDisplayName()Lnet/minecraft/network/chat/Component;", at = @At("RETURN"), cancellable = true)


### PR DESCRIPTION
I added this so that players standing on afk farms (placing blocks/attacking mobs) can be detected as sessile.
It's also the only detection method that can't be disabled.
I don't know if this would fit into your vision, so feel free to close it.