### PR TITLE
Implemented a configurable way to skip play time stat while sessile

### DIFF
--- a/src/main/java/net/bytzo/sessility/SessilityProperties.java
+++ b/src/main/java/net/bytzo/sessility/SessilityProperties.java
@@ -22,6 +22,7 @@ public class SessilityProperties extends Settings<SessilityProperties> {
 	public final int sessileTimeout = this.get("sessile-timeout", 240);
 	public final boolean skipSessileInPlayerCount = this.get("skip-sessile-in-player-count", false);
 	public final boolean skipSessileInSleepCount = this.get("skip-sessile-in-sleep-count", true);
+	public final boolean skipPlayTimeStat = this.get("skip-play-time-stat", false);
 
 	public SessilityProperties(Properties properties) {
 		super(properties);

--- a/src/main/java/net/bytzo/sessility/mixins/PlayerMixin.java
+++ b/src/main/java/net/bytzo/sessility/mixins/PlayerMixin.java
@@ -10,6 +10,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.bytzo.sessility.Sessility;
@@ -119,5 +120,11 @@ public abstract class PlayerMixin {
 		// update trackers
 		this.last_xRot = xRot;
 		this.last_yRot = yRot;
+	}
+
+	@Redirect(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Player;awardStat(Lnet/minecraft/resources/ResourceLocation;)V", ordinal = 0))
+	private void preventPlayTimeStatAward(Player player, ResourceLocation resourceLocation) {
+		if (((SessilePlayer) player).isSessile() && Sessility.settings().properties().skipPlayTimeStat) return;
+		player.awardStat(resourceLocation);
 	}
 }


### PR DESCRIPTION
This feature allows for the server owner to configure wether the play time stat should be increased while a player is sessile

Potentially addresses https://github.com/bytzo/sessility/issues/9 since subtracting the stat PLAY_TIME from TOTAL_WORLD_TIME could allow for a way to see the total amount of ticks a player has been sessile